### PR TITLE
Incremental update

### DIFF
--- a/Array.mpl
+++ b/Array.mpl
@@ -7,11 +7,11 @@ makeArrayRangeRaw: [{
   dataBegin:;
   dataSize: copy dynamic;
   schema elementType: @dataBegin;
-  virtual elementSize: dataBegin storageSize;
-  dataBegin storageAddress @elementType addressToReference !dataBegin #dynamize
+  virtual elementSize: @dataBegin storageSize;
+  @dataBegin storageAddress @elementType addressToReference !dataBegin #dynamize
 
   getBufferBegin: [
-    dataBegin storageAddress
+    @dataBegin storageAddress
   ];
 
   at: [
@@ -103,150 +103,160 @@ makeSubRange: [
   rangeEndIndex rangeBeginIndex - arg.getBufferBegin arg.elementSize rangeBeginIndex Natx cast * + @arg.@elementType addressToReference makeArrayRangeRaw
 ];
 
-Array: [
-  {
-    virtual CONTAINER: ();
-    virtual ARRAY: ();
-    virtual SCHEMA_NAME: "ARRAY";
-    schema elementType:;
-    dataBegin: 0nx @elementType addressToReference;
-    dataSize: 0 dynamic;
-    dataReserve: 0 dynamic;
-    virtual elementSize: elementType storageSize;
+Array: [{
+  virtual CONTAINER: ();
+  virtual ARRAY: ();
+  virtual SCHEMA_NAME: "ARRAY";
+  schema elementType:;
+  dataBegin: 0nx @elementType addressToReference;
+  dataSize: 0 dynamic;
+  dataReserve: 0 dynamic;
+  virtual elementSize: elementType storageSize;
 
-    getBufferBegin: [
-      dataBegin storageAddress
-    ];
+  getBufferBegin: [
+    @dataBegin storageAddress
+  ];
 
-    at: [
-      copy index:;
-      index 0i32 same not [0 .ONLY_I32_ALLOWED] when
-      [index 0 < not [index dataSize <] &&] "Index is out of range!" assert
+  at: [
+    copy index:;
+    index 0i32 same not [0 .ONLY_I32_ALLOWED] when
+    [index 0 < not [index dataSize <] &&] "Index is out of range!" assert
+    getBufferBegin index Natx cast elementSize * + @elementType addressToReference
+  ];
 
-      getBufferBegin index Natx cast elementSize * + @elementType addressToReference
-    ];
+  erase: [
+    copy index:;
+    index 0i32 same not [0 .ONLY_I32_ALLOWED] when
+    [index 0 < not [index dataSize <] &&] "Index is out of range!" assert
 
-    getSize: [dataSize copy];
+    index getSize 1 - < [
+      last move index at set
+    ] when
 
-    getArrayRange: [
-      dataSize @dataBegin storageAddress @elementType addressToReference makeArrayRangeRaw
-    ];
+    popBack
+  ];
 
-    getNextReserve: [
-      dataReserve dataReserve 4 / + 4 +
-    ];
+  getSize: [dataSize copy];
 
-    setReserve: [
-      copy newReserve:;
-      [newReserve dataReserve < not] "New reserve is less than old reserve!" assert
-      newReserve Natx cast elementSize * getBufferBegin mplRealloc
-      @elementType addressToReference !dataBegin
-      newReserve @dataReserve set
-    ];
+  getArrayRange: [
+    dataSize @dataBegin storageAddress @elementType addressToReference makeArrayRangeRaw
+  ];
 
-    addReserve: [
-      dataSize dataReserve = [
-        getNextReserve setReserve
-      ] when
-    ];
+  getNextReserve: [
+    dataReserve dataReserve 4 / + 4 +
+  ];
 
-    pushBack: [
-      elementIsMoved: isMoved;
-      element:;
-      addReserve
-      dataSize 1 + @dataSize set
-      newElement: dataSize 1 - at;
-      @newElement manuallyInitVariable
-      @element elementIsMoved moveIf @newElement set
-    ];
+  setReserve: [
+    copy newReserve:;
+    [newReserve dataReserve < not] "New reserve is less than old reserve!" assert
+    newReserve Natx cast elementSize * getBufferBegin mplRealloc
+    @elementType addressToReference !dataBegin
+    newReserve @dataReserve set
+  ];
 
-    shrink: [
-      copy newSize: dynamic;
-      [newSize dataSize > not] "Shrinked size is bigged than old size!" assert
+  addReserve: [
+    dataSize dataReserve = [
+      getNextReserve setReserve
+    ] when
+  ];
 
-      i: dataSize copy;
-      [i newSize >] [
-        i 1 - @i set
-        i at manuallyDestroyVariable
-      ] while
-      newSize @dataSize set
-    ];
+  pushBack: [
+    elementIsMoved: isMoved;
+    element:;
+    addReserve
+    dataSize 1 + @dataSize set
+    newElement: dataSize 1 - at;
+    @newElement manuallyInitVariable
+    @element elementIsMoved moveIf @newElement set
+  ];
 
-    popBack: [
-      [dataSize 0 >] "Pop from empty array!" assert
-      dataSize 1 - shrink
-    ];
+  shrink: [
+    copy newSize: dynamic;
+    [newSize dataSize > not] "Shrinked size is bigged than old size!" assert
 
-    last: [
-      dataSize 1 - at
-    ];
+    i: dataSize copy;
+    [i newSize >] [
+      i 1 - @i set
+      i at manuallyDestroyVariable
+    ] while
+    newSize @dataSize set
+  ];
 
-    enlarge: [
-      copy newSize: dynamic;
-      [newSize dataSize < not] "Enlarged size is less than old size!" assert
+  popBack: [
+    [dataSize 0 >] "Pop from empty array!" assert
+    dataSize 1 - shrink
+  ];
 
-      dataReserve newSize < [
-        newReserve: getNextReserve;
-        newReserve newSize < [newSize @newReserve set] when
-        newReserve setReserve
-      ] when
+  last: [
+    dataSize 1 - at
+  ];
 
-      i: dataSize copy;
-      newSize @dataSize set
-      [i dataSize <] [
-        i at manuallyInitVariable
-        i 1 + @i set
-      ] while
-    ];
+  enlarge: [
+    copy newSize: dynamic;
+    [newSize dataSize < not] "Enlarged size is less than old size!" assert
 
-    resize: [
-      copy newSize: dynamic;
-      newSize dataSize = [
+    dataReserve newSize < [
+      newReserve: getNextReserve;
+      newReserve newSize < [newSize @newReserve set] when
+      newReserve setReserve
+    ] when
+
+    i: dataSize copy;
+    newSize @dataSize set
+    [i dataSize <] [
+      i at manuallyInitVariable
+      i 1 + @i set
+    ] while
+  ];
+
+  resize: [
+    copy newSize: dynamic;
+    newSize dataSize = [
+    ] [
+      newSize dataSize < [
+        newSize shrink
       ] [
-        newSize dataSize < [
-          newSize shrink
-        ] [
-          newSize enlarge
-        ] if
+        newSize enlarge
       ] if
-    ];
+    ] if
+  ];
 
-    clear: [
-      0 dynamic shrink
-    ];
+  clear: [
+    0 dynamic shrink
+  ];
 
-    release: [
-      clear
-      addr: getBufferBegin;
-      addr 0nx = not [addr mplFree] when
-      0nx @elementType addressToReference !dataBegin
-      0 dynamic @dataSize set
-      0 dynamic @dataReserve set
-    ];
+  release: [
+    clear
+    addr: getBufferBegin;
+    addr 0nx = not [addr mplFree] when
+    0nx @elementType addressToReference !dataBegin
+    0 dynamic @dataSize set
+    0 dynamic @dataReserve set
+  ];
 
-    INIT: [
-      0nx @elementType addressToReference !dataBegin
-      0 dynamic @dataSize set
-      0 dynamic @dataReserve set
-    ];
+  INIT: [
+    0nx @elementType addressToReference !dataBegin
+    0 dynamic @dataSize set
+    0 dynamic @dataReserve set
+  ];
 
-    ASSIGN: [
-      other:;
-      other.dataSize resize
+  ASSIGN: [
+    other:;
+    other.dataSize resize
 
-      i: 0 dynamic;
-      [i dataSize <] [
-        i other.at i at set
-        i 1 + @i set
-      ] while
-    ];
+    i: 0 dynamic;
+    [i dataSize <] [
+      i other.at i at set
+      i 1 + @i set
+    ] while
+  ];
 
-    DIE: [
-      clear
-      addr: getBufferBegin;
-      addr 0nx = not [addr mplFree] when
-    ];
-  }];
+  DIE: [
+    clear
+    addr: getBufferBegin;
+    addr 0nx = not [addr mplFree] when
+  ];
+}];
 
 makeArray: [
   listIsMoved: isMoved;

--- a/HashTable.mpl
+++ b/HashTable.mpl
@@ -88,6 +88,33 @@ HashTable: [
       ] call
     ];
 
+    erase: [
+      key:;
+      keyHash: @key hash dynamic;
+      [
+        dataSize 0 = not [
+          bucketIndex: keyHash data.dataSize 1 - 0n32 cast and 0 cast;
+          curBucket: bucketIndex @data.at;
+
+          i: 0 dynamic;
+          [
+            i curBucket.dataSize < [
+              node: i @curBucket.at;
+              node.key key = [
+                i @curBucket.erase
+                FALSE
+              ] [
+                i 1 + @i set TRUE
+              ] if
+            ] [
+              [FALSE] "Erasing unexisting element!" assert
+              FALSE
+            ] if
+          ] loop
+        ] when
+      ] call
+    ];
+
     insertUnsafe: [ # make find before please
       valueIsMoved: isMoved;
       value:;

--- a/Pool.mpl
+++ b/Pool.mpl
@@ -55,7 +55,7 @@ Pool: [
 
     at: [
       copy index:;
-      [index valid] "Element is invalid!" assert
+      [index valid] "Pool::at: element is invalid!" assert
       index elementAt
     ];
 
@@ -65,7 +65,7 @@ Pool: [
 
     erase: [
       copy index:;
-      [index valid] "Element is invalid!" assert
+      [index valid] "Pool::erase: element is invalid!" assert
       index getAddressByIndex @elementSchema addressToReference manuallyDestroyVariable
       firstFree index nextFreeAt set
 
@@ -183,7 +183,9 @@ Pool: [
 
     DIE: [
       clear
-      data mplFree
+      data 0nx = not [
+        data mplFree
+      ] when
     ];
   }
 ];

--- a/String.mpl
+++ b/String.mpl
@@ -522,7 +522,7 @@ textSize: ["STRING" has] [.getTextSize Natx cast] pfunc;
 makeStringView: [0 .CANNOT_MAKE_STRING_VIEW];
 
 makeStringView: ["" same] [
-  copy arg:;
+  arg:;
   arg textSize Int32 cast dynamic arg storageAddress Nat8 addressToReference makeStringViewRaw
 ] pfunc;
 

--- a/Xml.mpl
+++ b/Xml.mpl
@@ -391,6 +391,8 @@ xmlInternal: {
           ascii.nCode ["no" skipString]
           ["expected y or n" lexicalError]
         ) case
+
+        "'" skipString
       ]
       ascii.quote [
         iterateChecked

--- a/control.mpl
+++ b/control.mpl
@@ -10,10 +10,23 @@ isCodeRef: [TRUE static];
 isCodeRef: [storageSize TRUE static] [FALSE static] pfunc;
 
 isCopyable: [drop FALSE];
-isCopyable: [x:; @x storageSize 0nx > [@x Ref] [@x copy] uif copy TRUE] [drop TRUE] pfunc;
+isCopyable: [x:; @x storageSize 0nx > [@x Ref] [@x] uif copy TRUE] [drop TRUE] pfunc;
 
 failProc: [
   storageAddress printAddr
+
+  trace: getCallTrace;
+  [
+    trace.first trace.last is [
+      FALSE
+    ] [
+      () LF printf
+      (trace.last.name trace.last.line copy trace.last.column copy) "in %s at %i:%i" printf
+      trace.last.prev trace.last addressToReference @trace.!last
+      TRUE
+    ] if
+  ] loop
+
   2 exit
 ];
 
@@ -75,12 +88,12 @@ times: [
 
 assert: [
   DEBUG [
-    copy message:;
+    message:;
     call not [
       message failProc
     ] when
   ] [
-    copy message:; condition:;
+    message:; condition:;
   ] if
 ];
 


### PR DESCRIPTION
# Array

- `Array` and `ArrayRange` can store callable objects now
- added method `erase` `(index - )` — erases element by index and moves the last element in vacant place; if the last element is erased, the method is equivalent to `popBack`

# Control
- `failProc` now shows stack trace after user message

# HashTable
- added method `erase` `(key - )` — erases element with corresponding `key`

# Xml
- fixed parser bug with single quotes `'` in SDDecl