### PR TITLE
Incremental update

### DIFF
--- a/Array.mpl
+++ b/Array.mpl
@@ -7,11 +7,11 @@ makeArrayRangeRaw: [{
   dataBegin:;
   dataSize: copy dynamic;
   schema elementType: @dataBegin;
-  virtual elementSize: dataBegin storageSize;
-  dataBegin storageAddress @elementType addressToReference !dataBegin #dynamize
+  virtual elementSize: @dataBegin storageSize;
+  @dataBegin storageAddress @elementType addressToReference !dataBegin #dynamize
 
   getBufferBegin: [
-    dataBegin storageAddress
+    @dataBegin storageAddress
   ];
 
   at: [
@@ -115,7 +115,7 @@ Array: [
     virtual elementSize: elementType storageSize;
 
     getBufferBegin: [
-      dataBegin storageAddress
+      @dataBegin storageAddress
     ];
 
     at: [

--- a/Array.mpl
+++ b/Array.mpl
@@ -162,7 +162,7 @@ Array: [
 
     shrink: [
       copy newSize: dynamic;
-      [newSize dataSize > not] "Shrinked size is bigged than old size!" assert
+      [newSize dataSize > not] "Shrinked size is bigger than the old size!" assert
 
       i: dataSize copy;
       [i newSize >] [

--- a/String.mpl
+++ b/String.mpl
@@ -522,7 +522,7 @@ textSize: ["STRING" has] [.getTextSize Natx cast] pfunc;
 makeStringView: [0 .CANNOT_MAKE_STRING_VIEW];
 
 makeStringView: ["" same] [
-  copy arg:;
+  arg:;
   arg textSize Int32 cast dynamic arg storageAddress Nat8 addressToReference makeStringViewRaw
 ] pfunc;
 

--- a/Xml.mpl
+++ b/Xml.mpl
@@ -391,6 +391,8 @@ xmlInternal: {
           ascii.nCode ["no" skipString]
           ["expected y or n" lexicalError]
         ) case
+
+        "'" skipString
       ]
       ascii.quote [
         iterateChecked

--- a/control.mpl
+++ b/control.mpl
@@ -75,12 +75,12 @@ times: [
 
 assert: [
   DEBUG [
-    copy message:;
+    message:;
     call not [
       message failProc
     ] when
   ] [
-    copy message:; condition:;
+    message:; condition:;
   ] if
 ];
 

--- a/control.mpl
+++ b/control.mpl
@@ -14,6 +14,19 @@ isCopyable: [x:; @x storageSize 0nx > [@x Ref] [@x] uif copy TRUE] [drop TRUE] p
 
 failProc: [
   storageAddress printAddr
+
+  trace: getCallTrace;
+  [
+    trace.first trace.last is [
+      FALSE
+    ] [
+      () LF printf
+      (trace.last.name trace.last.line copy trace.last.column copy) "in %s at %i:%i" printf
+      trace.last.prev trace.last addressToReference @trace.!last
+      TRUE
+    ] if
+  ] loop
+
   2 exit
 ];
 

--- a/control.mpl
+++ b/control.mpl
@@ -10,7 +10,7 @@ isCodeRef: [TRUE static];
 isCodeRef: [storageSize TRUE static] [FALSE static] pfunc;
 
 isCopyable: [drop FALSE];
-isCopyable: [x:; @x storageSize 0nx > [@x Ref] [@x copy] uif copy TRUE] [drop TRUE] pfunc;
+isCopyable: [x:; @x storageSize 0nx > [@x Ref] [@x] uif copy TRUE] [drop TRUE] pfunc;
 
 failProc: [
   storageAddress printAddr


### PR DESCRIPTION
# Array

- `Array` and `ArrayRange` can store callable objects now
- added method `erase` `(index - )` — erases element by index and moves the last element in vacant place; if the last element is erased, the method is equivalent to `popBack`

# Control
- `failProc` now shows stack trace after user message

# HashTable
- added method `erase` `(key - )` — erases element with corresponding `key`

# Xml
- fixed parser bug with single quotes `'` in SDDecl