### PR TITLE
LFH allocator

### DIFF
--- a/Array.mpl
+++ b/Array.mpl
@@ -149,7 +149,7 @@ Array: [{
   setReserve: [
     copy newReserve:;
     [newReserve dataReserve < not] "New reserve is less than old reserve!" assert
-    newReserve Natx cast elementSize * getBufferBegin mplRealloc
+    newReserve Natx cast elementSize * dataReserve Natx cast elementSize * getBufferBegin mplRealloc
     @elementType addressToReference !dataBegin
     newReserve @dataReserve set
   ];
@@ -228,7 +228,8 @@ Array: [{
   release: [
     clear
     addr: getBufferBegin;
-    addr 0nx = not [addr mplFree] when
+    size: dataReserve Natx cast elementSize *;
+    addr 0nx = not [size addr mplFree] when
     0nx @elementType addressToReference !dataBegin
     0 dynamic @dataSize set
     0 dynamic @dataReserve set
@@ -254,7 +255,8 @@ Array: [{
   DIE: [
     clear
     addr: getBufferBegin;
-    addr 0nx = not [addr mplFree] when
+    size: dataReserve Natx cast elementSize *;
+    addr 0nx = not [size addr mplFree] when
   ];
 }];
 

--- a/AvlMap.mpl
+++ b/AvlMap.mpl
@@ -301,7 +301,7 @@ AVLMap: [
         droppedChild: droppedNode.left 0nx = [droppedNode.right copy][droppedNode.left copy] if;
 
         droppedRef asNode manuallyDestroyVariable
-        droppedRef mplFree
+        nodeType storageSize droppedRef mplFree
         droppedChild @droppedRef set
       ] call
     ];
@@ -335,7 +335,7 @@ AVLMap: [
           node: nodeAddr asNode;
           node.left clearImpl
           node.right clearImpl
-          nodeAddr mplFree
+          nodeType storageSize nodeAddr mplFree
         ] when
       ];
 

--- a/Owner.mpl
+++ b/Owner.mpl
@@ -48,7 +48,13 @@ OwnerWithDestructor: [{
   ];
 }];
 
-Owner: [[manuallyDestroyVariable] OwnerWithDestructor];
+Owner: [
+  [
+    x:;
+    @x manuallyDestroyVariable
+    @x storageSize
+  ] OwnerWithDestructor
+];
 
 owner: [
   elementIsMoved: isMoved;

--- a/Pool.mpl
+++ b/Pool.mpl
@@ -14,6 +14,7 @@ Pool: [
     data: 0nx dynamic;
     dataSize: 0 dynamic;
     firstFree: -1 dynamic;
+    exactAllocatedMemSize: 0nx dynamic;
 
     getAddressByIndex: [
       Natx cast entrySize * data +
@@ -112,7 +113,8 @@ Pool: [
       firstFree 0 < [
         dataSize @index set
         dataSize 0 = [
-          entrySize 8nx * 1nx + mplMalloc @data set
+          entrySize 8nx * 1nx + @exactAllocatedMemSize set
+          exactAllocatedMemSize mplMalloc @data set
           7 [
             i 2 +
             i 1 + nextFreeAt set
@@ -128,7 +130,9 @@ Pool: [
           tailSize: dataSize 3n32 rshift;
           newTailSize: newDataSize 3n32 rshift;
 
-          entrySize newDataSize Natx cast * newTailSize Natx cast + data mplRealloc @data set
+          newExactAllocatedMemSize: entrySize newDataSize Natx cast * newTailSize Natx cast +;
+          newExactAllocatedMemSize exactAllocatedMemSize data mplRealloc @data set
+          newExactAllocatedMemSize @exactAllocatedMemSize set
 
           getNewTailAddressByIndex: [
             Natx cast newDataSize Natx cast entrySize * data + +
@@ -184,7 +188,7 @@ Pool: [
     DIE: [
       clear
       data 0nx = not [
-        data mplFree
+        exactAllocatedMemSize data mplFree
       ] when
     ];
   }

--- a/memory.mpl
+++ b/memory.mpl
@@ -13,8 +13,6 @@
 
 IntrusiveListNode: [{
   nextAddress: 0nx;
-  getNext: [nextAddress @self addressToReference];
-  setNext: [storageAddress !nextAddress];
 }];
 
 SL_MEMORY_MAX_CACHED_SIZE: [0x40000nx];
@@ -44,10 +42,10 @@ localStorage: 0nx SL_MEMORY_MAX_CACHED_SIZE 1nx + Int32 cast array;
   copy ptr:;
   copy size:;
   ptr 0nx = ~ [
-    size copy Natx storageSize max copy !size
     size SL_MEMORY_MAX_CACHED_SIZE > [
       ptr free
     ] [
+      size copy Natx storageSize max copy !size
       node: ptr IntrusiveListNode addressToReference;
       size Int32 cast localStorage @ @node.@nextAddress set
       @node storageAddress size Int32 cast @localStorage @ set
@@ -69,17 +67,16 @@ localStorage: 0nx SL_MEMORY_MAX_CACHED_SIZE 1nx + Int32 cast array;
     ] if
   ] [
     dest: newSize fastAllocate;
-    ptr 0nx = [oldSize 0nx =] || [
-      dest copy
-    ] [
+    ptr 0nx = [oldSize 0nx =] || ~ [
       num: newSize oldSize min copy;
       num ptr dest memcpy drop
       node: ptr IntrusiveListNode addressToReference;
       oldSizeIndex: oldSize Natx storageSize max Int32 cast;
       oldSizeIndex @localStorage @ @node.@nextAddress set
       @node storageAddress oldSizeIndex @localStorage @ set
-      dest storageAddress
     ] if
+
+    dest
   ] if
 ] "fastReallocate" exportFunction
 

--- a/memory.mpl
+++ b/memory.mpl
@@ -10,6 +10,79 @@
 {memptr1: Natx; memptr2: Natx; num: Natx;} Int32 {convention: cdecl;} "memcmp"  importFunction
 {dst: Natx; value: Int32; num: Natx;} Natx       {convention: cdecl;} "memset"  importFunction
 
+
+IntrusiveListNode: [{
+  nextAddress: 0nx;
+  getNext: [nextAddress @self addressToReference];
+  setNext: [storageAddress !nextAddress];
+}];
+
+SL_MEMORY_MAX_CACHED_SIZE: [0x40000nx];
+SL_MEMORY_MAX_CACHED_SIZE: [SL_MEMORY_MAX_CACHED_SIZE_OPTION TRUE] [SL_MEMORY_MAX_CACHED_SIZE_OPTION] pfunc;
+
+localStorage: 0nx SL_MEMORY_MAX_CACHED_SIZE 1nx + Int32 cast array;
+
+{size: Natx;} Natx {} [
+  copy size:;
+  size 0nx = [
+    0nx
+  ] [
+    size Natx storageSize max copy !size
+    node: IntrusiveListNode Ref;
+    size SL_MEMORY_MAX_CACHED_SIZE > [size Int32 cast localStorage @ 0nx =] || [
+      size malloc IntrusiveListNode addressToReference !node
+    ] [
+      size Int32 cast @localStorage @ IntrusiveListNode addressToReference !node
+      @node.nextAddress size Int32 cast @localStorage @ set
+    ] if
+
+    node storageAddress
+  ] if
+] "fastAllocate" exportFunction
+
+{ptr: Natx; size: Natx;} {} {} [
+  copy ptr:;
+  copy size:;
+  ptr 0nx = ~ [
+    size copy Natx storageSize max copy !size
+    size SL_MEMORY_MAX_CACHED_SIZE > [
+      ptr free
+    ] [
+      node: ptr IntrusiveListNode addressToReference;
+      size Int32 cast localStorage @ @node.@nextAddress set
+      @node storageAddress size Int32 cast @localStorage @ set
+    ] if
+  ] when
+] "fastDeallocate" exportFunction
+
+{ptr: Natx; oldSize: Natx; newSize: Natx;} Natx {} [
+  copy ptr:;
+  copy oldSize:;
+  copy newSize:;
+
+  oldSize SL_MEMORY_MAX_CACHED_SIZE > [
+    newSize 0nx = ~ [
+      newSize ptr realloc
+    ] [
+      ptr free
+      0nx
+    ] if
+  ] [
+    dest: newSize fastAllocate;
+    ptr 0nx = [oldSize 0nx =] || [
+      dest copy
+    ] [
+      num: newSize oldSize min copy;
+      num ptr dest memcpy drop
+      node: ptr IntrusiveListNode addressToReference;
+      oldSizeIndex: oldSize Natx storageSize max Int32 cast;
+      oldSizeIndex @localStorage @ @node.@nextAddress set
+      @node storageAddress oldSizeIndex @localStorage @ set
+      dest storageAddress
+    ] if
+  ] if
+] "fastReallocate" exportFunction
+
 getHeapUsedSize: [arg:; 0nx];
 getHeapUsedSize: [isCombined] [
   arg:;
@@ -36,14 +109,13 @@ new: [
 delete: [
   element:;
   @element manuallyDestroyVariable
-  @element storageAddress mplFree
+  @element storageSize @element storageAddress mplFree
 ];
 
 deleteWith: [
   destructor:;
   element:;
-  @element @destructor call
-  @element storageAddress mplFree
+  @element @destructor call @element storageAddress mplFree
 ];
 
 debugMemory: [FALSE];
@@ -69,6 +141,7 @@ debugMemory [
 
   mplRealloc: [
     copy ptr:;
+    drop
     copy size:;
 
     oldSize: ptr 0nx = [
@@ -93,6 +166,7 @@ debugMemory [
 
   mplFree: [
     copy ptr:;
+    drop
     oldSize: ptr 0nx = [
       0nx
     ] [
@@ -109,7 +183,7 @@ debugMemory [
     ptr free
   ];
 ] [
-  mplMalloc: [malloc];
-  mplRealloc: [realloc];
-  mplFree: [free];
+  mplMalloc: [fastAllocate];
+  mplRealloc: [fastReallocate];
+  mplFree: [fastDeallocate];
 ] uif

--- a/memory.mpl
+++ b/memory.mpl
@@ -14,8 +14,11 @@ IntrusiveListNode: [{
   nextAddress: 0nx;
 }];
 
-SL_MEMORY_MAX_CACHED_SIZE: [0x40000nx];
-SL_MEMORY_MAX_CACHED_SIZE: [SL_MEMORY_MAX_CACHED_SIZE_OPTION TRUE] [SL_MEMORY_MAX_CACHED_SIZE_OPTION] pfunc;
+haveSLMemoryMaxCachedSize: [FALSE];
+haveSLMemoryMaxCachedSize: [SL_MEMORY_MAX_CACHED_SIZE TRUE] [TRUE] pfunc;
+haveSLMemoryMaxCachedSize ~ [
+  SL_MEMORY_MAX_CACHED_SIZE: [0x40000nx];
+] [] uif
 
 localStorage: SL_MEMORY_MAX_CACHED_SIZE 1nx + Natx storageSize * malloc;
 localStorage 0nx = ["memory.mpl, error while initializing allocator: malloc returned 0" failProc] when

--- a/memory.mpl
+++ b/memory.mpl
@@ -74,7 +74,7 @@ localStorage: 0nx SL_MEMORY_MAX_CACHED_SIZE 1nx + Int32 cast array;
       oldSizeIndex: oldSize Natx storageSize max Int32 cast;
       oldSizeIndex @localStorage @ @node.@nextAddress set
       @node storageAddress oldSizeIndex @localStorage @ set
-    ] if
+    ] when
 
     dest
   ] if


### PR DESCRIPTION
# `memory.mpl`
A Low Fragmentation Heap Allocator implemented in `memory.mpl` as a wrapper around `malloc`, `free` and `realloc`. It stores freed memory blocks smaller than the given parameter, and reuses them whenever allocation request occur.
## New compiler argument
* `SL_MEMORY_MAX_CACHED_SIZE` - must be a Natx value. Memory blocks larger than this parameter would not be cached. Default value is `0x40000nx` (256kb).
## Changes in the interface
* `mplFree` - `(address -)` -> `(size address -)`
* `mplRealloc` - `(newSize oldAddress - newAddress)` -> `(newSize oldSize oldAddress - newAddress)`
* `deleteWith` - `destructor` argument must return memory block size

# Owner
## Changes in the interface
* `OwnerWithDestructor` - `destructor` argument must return memory block size