### PR TITLE
Remove year from the copyright notice from the source code; Change year of the copyright to reflect the year when the project was published

### DIFF
--- a/Array.mpl
+++ b/Array.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/AvlMap.mpl
+++ b/AvlMap.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Deque.mpl
+++ b/Deque.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Function.mpl
+++ b/Function.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/HashTable.mpl
+++ b/HashTable.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/IntrusiveDeque.mpl
+++ b/IntrusiveDeque.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/IntrusiveQueue.mpl
+++ b/IntrusiveQueue.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/IntrusiveStack.mpl
+++ b/IntrusiveStack.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Json.mpl
+++ b/Json.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2023 Matway Burkow
+Copyright (C) 2018 Matway Burkow
 
 This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 The content is for demonstration purposes only.

--- a/Mref.mpl
+++ b/Mref.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Owner.mpl
+++ b/Owner.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Pool.mpl
+++ b/Pool.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Pose.mpl
+++ b/Pose.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/PriorityQueue.mpl
+++ b/PriorityQueue.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Quaternion.mpl
+++ b/Quaternion.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/RandomLCG.mpl
+++ b/RandomLCG.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Span.mpl
+++ b/Span.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/SpanStatic.mpl
+++ b/SpanStatic.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Spinlock.mpl
+++ b/Spinlock.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/String.mpl
+++ b/String.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Union.mpl
+++ b/Union.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Variant.mpl
+++ b/Variant.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/Xml.mpl
+++ b/Xml.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/algebra.mpl
+++ b/algebra.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/algorithm.mpl
+++ b/algorithm.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/ascii.mpl
+++ b/ascii.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/atomic.ll
+++ b/atomic.ll
@@ -1,4 +1,4 @@
-; Copyright (C) 2023 Matway Burkow
+; Copyright (C) Matway Burkow
 ;
 ; This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 ; The content is for demonstration purposes only.

--- a/atomic.mpl
+++ b/atomic.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/control.mpl
+++ b/control.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/conventions.mpl
+++ b/conventions.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/file.mpl
+++ b/file.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/interface.mpl
+++ b/interface.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/errno.mpl
+++ b/linux/errno.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/linux.mpl
+++ b/linux/linux.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/posix.mpl
+++ b/linux/posix.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/runningTime.mpl
+++ b/linux/runningTime.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/socket.mpl
+++ b/linux/socket.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/sync/TcpAcceptor.mpl
+++ b/linux/sync/TcpAcceptor.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/sync/TcpConnection.mpl
+++ b/linux/sync/TcpConnection.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/sync/sync.mpl
+++ b/linux/sync/sync.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/linux/sync/syncPrivate.mpl
+++ b/linux/sync/syncPrivate.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/lockGuard.mpl
+++ b/lockGuard.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/memory.mpl
+++ b/memory.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/murmurHash.mpl
+++ b/murmurHash.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/objectTools.mpl
+++ b/objectTools.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/sha1.mpl
+++ b/sha1.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/sync/Context.mpl
+++ b/sync/Context.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/sync/ContextGroup.mpl
+++ b/sync/ContextGroup.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/sync/Event.mpl
+++ b/sync/Event.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/sync/Signal.mpl
+++ b/sync/Signal.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/linux/syncTest.mpl
+++ b/tests/linux/syncTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/ContextGroupTest.mpl
+++ b/tests/universal/ContextGroupTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/ContextTest.mpl
+++ b/tests/universal/ContextTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/EventTest.mpl
+++ b/tests/universal/EventTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/FunctionTest.mpl
+++ b/tests/universal/FunctionTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/PoseTest.mpl
+++ b/tests/universal/PoseTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/QuaternionTest.mpl
+++ b/tests/universal/QuaternionTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/SignalTest.mpl
+++ b/tests/universal/SignalTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/SpanStaticTest.mpl
+++ b/tests/universal/SpanStaticTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/SpanTest.mpl
+++ b/tests/universal/SpanTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/algorithmTest.mpl
+++ b/tests/universal/algorithmTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/controlTest.mpl
+++ b/tests/universal/controlTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/objectToolsTest.mpl
+++ b/tests/universal/objectToolsTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/objectTraitTest.mpl
+++ b/tests/universal/objectTraitTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/tests/universal/syncTest.mpl
+++ b/tests/universal/syncTest.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/ConditionVariable.mpl
+++ b/windows/ConditionVariable.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/Mutex.mpl
+++ b/windows/Mutex.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/TcpAcceptor.mpl
+++ b/windows/TcpAcceptor.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/TcpConnection.mpl
+++ b/windows/TcpConnection.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/Thread.mpl
+++ b/windows/Thread.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/dispatcher.mpl
+++ b/windows/dispatcher.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/errno.mpl
+++ b/windows/errno.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/gdi32.mpl
+++ b/windows/gdi32.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/hardwareConcurrency.mpl
+++ b/windows/hardwareConcurrency.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/kernel32.mpl
+++ b/windows/kernel32.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/ole32.mpl
+++ b/windows/ole32.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/opengl32.mpl
+++ b/windows/opengl32.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/runningTime.mpl
+++ b/windows/runningTime.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/shell32.mpl
+++ b/windows/shell32.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/sync/TcpAcceptor.mpl
+++ b/windows/sync/TcpAcceptor.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/sync/TcpConnection.mpl
+++ b/windows/sync/TcpConnection.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/sync/sync.mpl
+++ b/windows/sync/sync.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/sync/syncPrivate.mpl
+++ b/windows/sync/syncPrivate.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/user32.mpl
+++ b/windows/user32.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/winmm.mpl
+++ b/windows/winmm.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.

--- a/windows/ws2_32.mpl
+++ b/windows/ws2_32.mpl
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Matway Burkow
+# Copyright (C) Matway Burkow
 #
 # This repository and all its contents belong to Matway Burkow (referred here and below as "the owner").
 # The content is for demonstration purposes only.


### PR DESCRIPTION
The very first commit https://github.com/Matway/mpl-sl/commit/63d7e0e44cc437253fd767cb754606bb544337e3.