### PR TITLE
Fix [wrapIter.size] producing reference

### DIFF
--- a/algorithm.mpl
+++ b/algorithm.mpl
@@ -867,7 +867,7 @@ wrapIter: [{
   @sources ["size" has] all [
     size: [
       @sources fieldCount 0 = [0] [
-        0 @sources @ .size @sources fieldCount 1 - [i 1 + @sources @ .size min isRef [new] when] times
+        0 @sources @ .size @sources fieldCount 1 - [i 1 + @sources @ .size min new] times
       ] if
     ];
   ] [] uif

--- a/algorithm.mpl
+++ b/algorithm.mpl
@@ -867,7 +867,7 @@ wrapIter: [{
   @sources ["size" has] all [
     size: [
       @sources fieldCount 0 = [0] [
-        0 @sources @ .size @sources fieldCount 1 - [i 1 + @sources @ .size min] times
+        0 @sources @ .size @sources fieldCount 1 - [i 1 + @sources @ .size min new] times
       ] if
     ];
   ] [] uif

--- a/algorithm.mpl
+++ b/algorithm.mpl
@@ -867,7 +867,7 @@ wrapIter: [{
   @sources ["size" has] all [
     size: [
       @sources fieldCount 0 = [0] [
-        0 @sources @ .size @sources fieldCount 1 - [i 1 + @sources @ .size min new] times
+        0 @sources @ .size @sources fieldCount 1 - [i 1 + @sources @ .size min isRef [new] when] times
       ] if
     ];
   ] [] uif


### PR DESCRIPTION
# What

algorithm.wrapIter sets wrong iterator .size due to sending stack variable out without new.

# Reproducing

```
"Array"       use
"String"      use
"algorithm"   use
"control"     use
"objectTools" use

{} Int32 {} [
  a: (1 2 3) toArray;
  b: (1 2 3) toArray;
  (a.size " " b.size LF) printList
  (@a @b) wrapIter .size print LF print
  0
] "main" exportFunction
```

This example returns 3 3 37265 (for example) when compiled with -O0 and 3 3 0 when compiled with -O3 while it should be 3 3 3.

Bug manifest itself only when creating array from iter with -O3 (so array size would be inherited from iterator as zero) and looks like "Index is out of range!". It works with -O0 due to some magic